### PR TITLE
Set path2d attribute when updating the circle data

### DIFF
--- a/symmeplot/plot_artists.py
+++ b/symmeplot/plot_artists.py
@@ -142,7 +142,8 @@ class Circle3D(PathPatch3D, ArtistBase):
 
     def update_data(self, center: Sequence[float], radius: float,
                     normal: Sequence[float]):
-        self._segment3d = self._get_segment3d(self._get_2d_path(np.float64(radius)),
+        self._path2d = self._get_2d_path(np.float64(radius))
+        self._segment3d = self._get_segment3d(self._path2d,
                                               np.array(center, dtype=np.float64),
                                               np.array(normal, dtype=np.float64))
 


### PR DESCRIPTION
Was getting an error message the entire time that `Circle3D,_path2d` was not set. This is an easy fix which I guess is correct. It at least seems to work in such a way that it is detected that I hover above a circle and the error message has disappeared.