### PR TITLE
Support older versions of dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: poetry install --with test --all-extras
+        run: |
+          poetry install --with test --all-extras
+          pip install pytest-xdist
       - name: Run tests
         run: poetry run pytest
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -613,13 +613,13 @@ woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "furo"
-version = "2023.9.10"
+version = "2024.1.29"
 description = "A clean customisable Sphinx documentation theme."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "furo-2023.9.10-py3-none-any.whl", hash = "sha256:513092538537dc5c596691da06e3c370714ec99bc438680edc1debffb73e5bfc"},
-    {file = "furo-2023.9.10.tar.gz", hash = "sha256:5707530a476d2a63b8cad83b4f961f3739a69f4b058bcf38a03a39fa537195b2"},
+    {file = "furo-2024.1.29-py3-none-any.whl", hash = "sha256:3548be2cef45a32f8cdc0272d415fcb3e5fa6a0eb4ddfe21df3ecf1fe45a13cf"},
+    {file = "furo-2024.1.29.tar.gz", hash = "sha256:4d6b2fe3f10a6e36eb9cc24c1e7beb38d7a23fc7b3c382867503b7fcac8a1e02"},
 ]
 
 [package.dependencies]
@@ -1524,18 +1524,18 @@ xmp = ["defusedxml"]
 
 [[package]]
 name = "platformdirs"
-version = "4.1.0"
+version = "4.2.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.1.0-py3-none-any.whl", hash = "sha256:11c8f37bcca40db96d8144522d925583bdb7a31f7b0e37e3ed4318400a8e2380"},
-    {file = "platformdirs-4.1.0.tar.gz", hash = "sha256:906d548203468492d432bcb294d4bc2fff751bf84971fbb2c10918cc206ee420"},
+    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
+    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
 ]
 
 [package.extras]
-docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.1)", "sphinx-autodoc-typehints (>=1.24)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)"]
+docs = ["furo (>=2023.9.10)", "proselint (>=0.13)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)"]
 
 [[package]]
 name = "pluggy"
@@ -1764,13 +1764,13 @@ numpy = ">=1.20.0"
 
 [[package]]
 name = "pytest"
-version = "7.4.4"
+version = "8.0.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "pytest-7.4.4-py3-none-any.whl", hash = "sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8"},
-    {file = "pytest-7.4.4.tar.gz", hash = "sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280"},
+    {file = "pytest-8.0.0-py3-none-any.whl", hash = "sha256:50fb9cbe836c3f20f0dfa99c565201fb75dc54c8d76373cd1bde06b06657bdb6"},
+    {file = "pytest-8.0.0.tar.gz", hash = "sha256:249b1b0864530ba251b7438274c4d251c58d868edaaec8762893ad4a0d71c36c"},
 ]
 
 [package.dependencies]
@@ -1778,7 +1778,7 @@ colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<2.0"
+pluggy = ">=1.3.0,<2.0"
 tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
@@ -2004,13 +2004,13 @@ cffi = {version = "*", markers = "implementation_name == \"pypy\""}
 
 [[package]]
 name = "referencing"
-version = "0.32.1"
+version = "0.33.0"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "referencing-0.32.1-py3-none-any.whl", hash = "sha256:7e4dc12271d8e15612bfe35792f5ea1c40970dadf8624602e33db2758f7ee554"},
-    {file = "referencing-0.32.1.tar.gz", hash = "sha256:3c57da0513e9563eb7e203ebe9bb3a1b509b042016433bd1e45a2853466c3dd3"},
+    {file = "referencing-0.33.0-py3-none-any.whl", hash = "sha256:39240f2ecc770258f28b642dd47fd74bc8b02484de54e1882b74b35ebd779bd5"},
+    {file = "referencing-0.33.0.tar.gz", hash = "sha256:c775fedf74bc0f9189c2a3be1c12fd03e8c23f4d371dce795df44e06c5b412f7"},
 ]
 
 [package.dependencies]
@@ -2148,28 +2148,28 @@ files = [
 
 [[package]]
 name = "ruff"
-version = "0.1.14"
+version = "0.1.15"
 description = "An extremely fast Python linter and code formatter, written in Rust."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "ruff-0.1.14-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:96f76536df9b26622755c12ed8680f159817be2f725c17ed9305b472a757cdbb"},
-    {file = "ruff-0.1.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ab3f71f64498c7241123bb5a768544cf42821d2a537f894b22457a543d3ca7a9"},
-    {file = "ruff-0.1.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7060156ecc572b8f984fd20fd8b0fcb692dd5d837b7606e968334ab7ff0090ab"},
-    {file = "ruff-0.1.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a53d8e35313d7b67eb3db15a66c08434809107659226a90dcd7acb2afa55faea"},
-    {file = "ruff-0.1.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bea9be712b8f5b4ebed40e1949379cfb2a7d907f42921cf9ab3aae07e6fba9eb"},
-    {file = "ruff-0.1.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:2270504d629a0b064247983cbc495bed277f372fb9eaba41e5cf51f7ba705a6a"},
-    {file = "ruff-0.1.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80258bb3b8909b1700610dfabef7876423eed1bc930fe177c71c414921898efa"},
-    {file = "ruff-0.1.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:653230dd00aaf449eb5ff25d10a6e03bc3006813e2cb99799e568f55482e5cae"},
-    {file = "ruff-0.1.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87b3acc6c4e6928459ba9eb7459dd4f0c4bf266a053c863d72a44c33246bfdbf"},
-    {file = "ruff-0.1.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6b3dadc9522d0eccc060699a9816e8127b27addbb4697fc0c08611e4e6aeb8b5"},
-    {file = "ruff-0.1.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1c8eca1a47b4150dc0fbec7fe68fc91c695aed798532a18dbb1424e61e9b721f"},
-    {file = "ruff-0.1.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:62ce2ae46303ee896fc6811f63d6dabf8d9c389da0f3e3f2bce8bc7f15ef5488"},
-    {file = "ruff-0.1.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b2027dde79d217b211d725fc833e8965dc90a16d0d3213f1298f97465956661b"},
-    {file = "ruff-0.1.14-py3-none-win32.whl", hash = "sha256:722bafc299145575a63bbd6b5069cb643eaa62546a5b6398f82b3e4403329cab"},
-    {file = "ruff-0.1.14-py3-none-win_amd64.whl", hash = "sha256:e3d241aa61f92b0805a7082bd89a9990826448e4d0398f0e2bc8f05c75c63d99"},
-    {file = "ruff-0.1.14-py3-none-win_arm64.whl", hash = "sha256:269302b31ade4cde6cf6f9dd58ea593773a37ed3f7b97e793c8594b262466b67"},
-    {file = "ruff-0.1.14.tar.gz", hash = "sha256:ad3f8088b2dfd884820289a06ab718cde7d38b94972212cc4ba90d5fbc9955f3"},
+    {file = "ruff-0.1.15-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5fe8d54df166ecc24106db7dd6a68d44852d14eb0729ea4672bb4d96c320b7df"},
+    {file = "ruff-0.1.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6f0bfbb53c4b4de117ac4d6ddfd33aa5fc31beeaa21d23c45c6dd249faf9126f"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0d432aec35bfc0d800d4f70eba26e23a352386be3a6cf157083d18f6f5881c8"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9405fa9ac0e97f35aaddf185a1be194a589424b8713e3b97b762336ec79ff807"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c66ec24fe36841636e814b8f90f572a8c0cb0e54d8b5c2d0e300d28a0d7bffec"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6f8ad828f01e8dd32cc58bc28375150171d198491fc901f6f98d2a39ba8e3ff5"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86811954eec63e9ea162af0ffa9f8d09088bab51b7438e8b6488b9401863c25e"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fd4025ac5e87d9b80e1f300207eb2fd099ff8200fa2320d7dc066a3f4622dc6b"},
+    {file = "ruff-0.1.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b17b93c02cdb6aeb696effecea1095ac93f3884a49a554a9afa76bb125c114c1"},
+    {file = "ruff-0.1.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ddb87643be40f034e97e97f5bc2ef7ce39de20e34608f3f829db727a93fb82c5"},
+    {file = "ruff-0.1.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:abf4822129ed3a5ce54383d5f0e964e7fef74a41e48eb1dfad404151efc130a2"},
+    {file = "ruff-0.1.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6c629cf64bacfd136c07c78ac10a54578ec9d1bd2a9d395efbee0935868bf852"},
+    {file = "ruff-0.1.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1bab866aafb53da39c2cadfb8e1c4550ac5340bb40300083eb8967ba25481447"},
+    {file = "ruff-0.1.15-py3-none-win32.whl", hash = "sha256:2417e1cb6e2068389b07e6fa74c306b2810fe3ee3476d5b8a96616633f40d14f"},
+    {file = "ruff-0.1.15-py3-none-win_amd64.whl", hash = "sha256:3837ac73d869efc4182d9036b1405ef4c73d9b1f88da2413875e34e0d6919587"},
+    {file = "ruff-0.1.15-py3-none-win_arm64.whl", hash = "sha256:9a933dfb1c14ec7a33cceb1e49ec4a16b51ce3c20fd42663198746efc0427360"},
+    {file = "ruff-0.1.15.tar.gz", hash = "sha256:f6dfa8c1b21c913c326919056c390966648b680966febcb796cc9d1aaab8564e"},
 ]
 
 [[package]]
@@ -2477,17 +2477,18 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.1.0"
+version = "2.2.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "urllib3-2.1.0-py3-none-any.whl", hash = "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3"},
-    {file = "urllib3-2.1.0.tar.gz", hash = "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"},
+    {file = "urllib3-2.2.0-py3-none-any.whl", hash = "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"},
+    {file = "urllib3-2.2.0.tar.gz", hash = "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20"},
 ]
 
 [package.extras]
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
@@ -2566,4 +2567,4 @@ pg-backend = ["pyopengl", "pyqt6", "pyqtgraph"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f377408c7ab89bd6df9b4cd20484e2ede89f352a025ea7611841a62869aaf9a9"
+content-hash = "d58ca16d1c882abb349b524682a73be2629fbe87b97e81eee2422c4176fbe30c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2567,4 +2567,4 @@ pg-backend = ["pyopengl", "pyqt6", "pyqtgraph"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d58ca16d1c882abb349b524682a73be2629fbe87b97e81eee2422c4176fbe30c"
+content-hash = "9988f8796a2d92962a43d5e7a4fac9e09dbf92e1620fa1bb8457c3caf3423978"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,9 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.9"
 sympy = "^1.12"
-numpy = "^1.26.0"
+numpy = "^1.21.6"
 
-matplotlib = {version = "^3.8.2", optional = true}
+matplotlib = {version = "^3.8", optional = true}
 pyqtgraph = {version = "^0.13.3", optional = true}
 pyqt6 = {version = "^6.6.1", optional = true}
 pyopengl = {version = "^3.1.7", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ mpl_backend = ["matplotlib"]
 pg_backend = ["pyqtgraph", "pyqt6", "pyopengl"]
 
 [tool.poetry.group.lint.dependencies]
-ruff = "^0.1.14"
+ruff = "^0.1.15"
 pre-commit = "^3.6.0"
 
 [tool.poetry.group.test.dependencies]
-pytest = "^7.4.4"
+pytest = "^8.0.0"
 pytest-mock = "^3.12.0"
 
 [tool.poetry.group.docs.dependencies]
@@ -37,7 +37,7 @@ sphinx = "^7.2.6"
 jupyter-sphinx = "^0.5.3"
 autodocsumm = "^0.2.12"
 ipykernel = "^6.29.0"
-furo = "^2023.9.10"
+furo = "^2024.1.29"
 
 [project.urls]
 "Homepage" = "https://github.com/tjstienstra/symmeplot"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-target-version = "py37"
+target-version = "py39"
 select = ["A", "B", "C", "D", "E", "F", "I", "N", "Q", "W", "NPY", "RUF", "SIM", "TID",
           "T20", "UP"]
 ignore = ["A003", "C901", "D100", "D105", "D107", "D203", "D213", "RUF200"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ python = "^3.9"
 sympy = "^1.12"
 numpy = "^1.21.6"
 
-matplotlib = {version = "^3.8", optional = true}
+matplotlib = {version = "^3.7", optional = true}
 pyqtgraph = {version = "^0.13.3", optional = true}
 pyqt6 = {version = "^6.6.1", optional = true}
 pyopengl = {version = "^3.1.7", optional = true}

--- a/src/symmeplot/core/plot_base.py
+++ b/src/symmeplot/core/plot_base.py
@@ -93,6 +93,7 @@ class PlotBase(ABC):
         Notes
         -----
         Subclasses should also implement the setter of this property.
+
         """
         return self._visible
 
@@ -132,6 +133,7 @@ class PlotBase(ABC):
             The artist to be added.
         exprs : expression or tuple of expressions
             Args used to update the artist in the form of expressions.
+
         """
         if not isinstance(artist, ArtistBase):
             raise TypeError("'artist' should be a valid Artist object.")

--- a/src/symmeplot/core/plot_objects.py
+++ b/src/symmeplot/core/plot_objects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 import numpy.typing as npt

--- a/src/symmeplot/core/plot_objects.py
+++ b/src/symmeplot/core/plot_objects.py
@@ -43,6 +43,7 @@ class PlotPointMixin:
     Notes
     -----
     The subclass should create and add the artist in the constructor.
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -75,6 +76,7 @@ class PlotLineMixin:
     Notes
     -----
     The subclass should create and add the artist in the constructor.
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -104,6 +106,7 @@ class PlotLineMixin:
         Notes
         -----
         The form of the expression is ``((x0, x1, ...), (y0, y1, ...), (z0, z1, ...))``.
+
         """
         vs = []
         for point in self.line:
@@ -118,6 +121,7 @@ class PlotVectorMixin(OriginMixin):
     Notes
     -----
     The subclass should create and add the artist in the constructor.
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -160,6 +164,7 @@ class PlotFrameMixin(OriginMixin):
     -----
     The subclass should instantiate the PlotVector objects in the constructor.
     The children should be added in the following order: x, y, z.
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -206,6 +211,7 @@ class PlotBodyMixin:
     The subclass should instantiate the PlotFrame and PlotPoint objects in the
     constructor. If the body has a frame, then the PlotFrame should be the second child.
     The PlotPoint representing the center of mass should always be the first child.
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,

--- a/src/symmeplot/core/scene.py
+++ b/src/symmeplot/core/scene.py
@@ -324,5 +324,6 @@ class SceneBase(ABC):
             Time interval between frames in milliseconds. Default is 30.
         **kwargs
             Keyword arguments are parsed to the internally used animation function.
+
         """
         raise NotImplementedError("'animate' has not been implemented in this backend.")

--- a/src/symmeplot/core/scene.py
+++ b/src/symmeplot/core/scene.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC
-from typing import Any, Callable, Iterable
+from collections.abc import Iterable
+from typing import Any, Callable
 
 from sympy import lambdify
 from sympy.physics.mechanics import Point, ReferenceFrame, Vector

--- a/src/symmeplot/matplotlib/artists.py
+++ b/src/symmeplot/matplotlib/artists.py
@@ -64,6 +64,7 @@ class Vector3D(FancyArrowPatch, MplArtistBase):
     -----
     This class is inspired by
     https://gist.github.com/WetHat/1d6cd0f7309535311a539b42cccca89c
+
     """
 
     def __init__(self, origin: Sequence[float], vector: Sequence[float], *args,
@@ -100,6 +101,7 @@ class Circle3D(PathPatch3D, MplArtistBase):
     Notes
     -----
     This class is inspired by https://stackoverflow.com/a/18228967/20185124
+
     """
 
     def __init__(self, center: Sequence[float], radius: float,

--- a/src/symmeplot/matplotlib/artists.py
+++ b/src/symmeplot/matplotlib/artists.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Sequence
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 from matplotlib.patches import Circle, FancyArrowPatch

--- a/src/symmeplot/matplotlib/plot_base.py
+++ b/src/symmeplot/matplotlib/plot_base.py
@@ -20,6 +20,7 @@ class MplPlotBase(PlotBase):
         The absolute origin with respect to which the object is positioned.
     name : str, optional
         Name of the plot object. Default is the name of the object being plotted.
+
     """
 
     def plot(self, ax=None):
@@ -34,6 +35,7 @@ class MplPlotBase(PlotBase):
         ----------
         ax : matplotlib.axes._subplots.Axes3DSubplot, optional
             Axes on which the artist should be added. The default is the active axes.
+
         """
         if ax is None:
             ax = gca()

--- a/src/symmeplot/matplotlib/plot_objects.py
+++ b/src/symmeplot/matplotlib/plot_objects.py
@@ -62,6 +62,7 @@ class PlotPoint(PlotPointMixin, MplPlotBase):
         plot_point.plot()  # Plot the point
         plot_point.values = f(0.2, 0.6, 0.3)
         plot_point.update()  # The point will now be on its new position
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -128,6 +129,7 @@ class PlotLine(PlotLineMixin, MplPlotBase):
         line_plot.plot()  # Plot the point
         line_plot.values = f(0.2, 0.6, 0.3)
         line_plot.update()  # The point will now be on its new position
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -188,6 +190,7 @@ class PlotVector(PlotVectorMixin, MplPlotBase):
         v_plot.values = sm.lambdify((), v_plot.get_expressions_to_evaluate())()
         v_plot.update()  # Updates the artist(s) to the new values
         v_plot.plot(ax)
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -274,6 +277,7 @@ class PlotFrame(PlotFrameMixin, MplPlotBase):
         A_plot.update()  # Updates the artist(s) to the new values
         N_plot.plot(ax)
         A_plot.plot(ax)
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -370,6 +374,7 @@ class PlotBody(PlotBodyMixin, MplPlotBase):
         body_plot.update()  # Updates the artist(s) to the new values
         ground_plot.plot(ax)
         body_plot.plot(ax)
+
     """
 
     def __init__(self, inertial_frame: ReferenceFrame, zero_point: Point,
@@ -417,6 +422,7 @@ class PlotBody(PlotBodyMixin, MplPlotBase):
         -------
         :class:`symmeplot.matplotlib.plot_artists.Circle3D`
             Circle artist.
+
         """
         if isinstance(center, Point):
             center = center.pos_from(self.zero_point)

--- a/src/symmeplot/matplotlib/plot_objects.py
+++ b/src/symmeplot/matplotlib/plot_objects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 from sympy import sympify

--- a/src/symmeplot/matplotlib/scene.py
+++ b/src/symmeplot/matplotlib/scene.py
@@ -128,6 +128,7 @@ class Scene3D(SceneBase):
         -------
         tuple of artists
             Returns the plotted artists
+
         """
         self.update()
         for plot_object in self._children:

--- a/src/symmeplot/matplotlib/scene.py
+++ b/src/symmeplot/matplotlib/scene.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Iterable
+from collections.abc import Iterable
+from typing import Any, Callable
 
 import matplotlib.pyplot as plt
 import numpy as np

--- a/src/symmeplot/pyqtgraph/artists.py
+++ b/src/symmeplot/pyqtgraph/artists.py
@@ -53,6 +53,7 @@ def create_tube_mesh_data(
     setting the radius to zero.
 
     >>> create_tube_mesh_data((0, 1), (0.3, 0), (0, 0, 0), (0, 0, 1));
+
     """
     if len(lengths) != len(radii) or len(lengths) < 2:
         raise ValueError(
@@ -197,6 +198,7 @@ class Vector3D(PgArtistBase):
     mesh_resolution : int, optional
         The number of points in the circle if plotted as mesh, by default defined as
         classattribute.
+
     """
 
     vector_radius: float | None = None

--- a/src/symmeplot/pyqtgraph/artists.py
+++ b/src/symmeplot/pyqtgraph/artists.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt

--- a/src/symmeplot/pyqtgraph/plot_objects.py
+++ b/src/symmeplot/pyqtgraph/plot_objects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 from sympy.physics.mechanics import Particle, Point, ReferenceFrame, RigidBody, Vector
 

--- a/src/symmeplot/pyqtgraph/scene.py
+++ b/src/symmeplot/pyqtgraph/scene.py
@@ -105,6 +105,7 @@ class Scene3D(SceneBase):
             Number of frames or iterable with frames.
         interval : int, optional
             Time interval between frames in milliseconds. Default is 30.
+
         """
         if isinstance(frames, int):
             frames = range(frames)

--- a/src/symmeplot/pyqtgraph/scene.py
+++ b/src/symmeplot/pyqtgraph/scene.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Callable
 
 import pyqtgraph as pg
 import pyqtgraph.opengl as gl

--- a/src/symmeplot/utilities/utilities.py
+++ b/src/symmeplot/utilities/utilities.py
@@ -13,6 +13,7 @@ def dcm_to_align_vectors(v1: Sequence[float], v2: Sequence[float]
     Notes
     -----
     Calculation is based on https://math.stackexchange.com/a/476311
+
     """
     v1 = np.array(v1, dtype=np.float64) / np.linalg.norm(v1)
     v2 = np.array(v2, dtype=np.float64) / np.linalg.norm(v2)

--- a/src/symmeplot/utilities/utilities.py
+++ b/src/symmeplot/utilities/utilities.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
It is in general good practice to also support older versions of dependencies to not constrain users to just the newest version.
This PR therefore reduces the version number of dependencies. The following method was used to determine the dependency versions:
- Development dependencies should be kept up to date with the newest version, as one uses a separate environment anyway.
- Constraint: the newest version must be supported.
- The numpy version is based on the [scipy toolchain roadmap of numpy](https://docs.scipy.org/doc/scipy/dev/toolchain.html#numpy). Scipy 1.10 does not support the newest version of numpy, scipy 1.11 does. The minimal required version of numpy by scipy 1.11 is 1.21.6
- The matplotlib version is the minor version of approximately a year ago.
- Pyqtgraph is a bit more problematic. They say to support pyqt6>=6.2, but they only support the newest version. Therefore, I decided to just depend on the newest for now. This includes pyopengl as well, which rarely gets an update.
- P.S. the sympy version is 1.12 because you just should not use an older version than that when solving mechanics problems.

`^` in poetry is explained [here](https://python-poetry.org/docs/dependency-specification/)